### PR TITLE
Minor refactoring

### DIFF
--- a/src/host/sndio/adapters.rs
+++ b/src/host/sndio/adapters.rs
@@ -1,5 +1,5 @@
-use crate::{Data, FrameCount, InputCallbackInfo, OutputCallbackInfo, Sample, SampleFormat};
-use std::convert::TryFrom;
+use crate::{Data, FrameCount, InputCallbackInfo, OutputCallbackInfo, Sample};
+use samples_formats::TypeSampleFormat;
 
 /// When given an input data callback that expects samples in the specified sample format, return
 /// an input data callback that expects samples in the I16 sample format. The `buffer_size` is in
@@ -7,31 +7,24 @@ use std::convert::TryFrom;
 pub(super) fn input_adapter_callback<T, D>(
     mut original_data_callback: D,
     buffer_size: FrameCount,
-    sample_format: SampleFormat,
 ) -> Box<dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static>
 where
     D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
-    T: TryFrom<i16> + Copy + Send + Default + 'static,
+    T: Sample + TypeSampleFormat + Copy + Send + Default + 'static,
 {
-    let mut adapted_buf = vec![T::default()].repeat(buffer_size as usize);
+    let mut adapted_buf = vec![T::default(); buffer_size as usize];
 
     Box::new(move |data: &Data, info: &InputCallbackInfo| {
         let data_slice: &[i16] = data.as_slice().unwrap(); // unwrap OK because data is always i16
         let adapted_slice = &mut adapted_buf;
         assert_eq!(data_slice.len(), adapted_slice.len());
-        for (i, adapted_ref) in adapted_slice.iter_mut().enumerate() {
-            *adapted_ref = T::try_from(data_slice[i]).unwrap_or_default();
+        for (adapted_ref, data_element) in adapted_slice.iter_mut().zip(data_slice.iter()) {
+            *adapted_ref = T::from(data_element);
         }
 
         // Note: we construct adapted_data here instead of in the parent function because adapted_buf needs
         // to be owned by the closure.
-        let adapted_data = unsafe {
-            Data::from_parts(
-                adapted_buf.as_mut_ptr() as *mut _,
-                buffer_size as usize, // TODO: this is converting a FrameCount to a number of samples; invalid for stereo!
-                sample_format,
-            )
-        };
+        let adapted_data = unsafe { data_from_vec(&mut adapted_buf) };
         original_data_callback(&adapted_data, info);
     })
 }
@@ -39,70 +32,39 @@ where
 /// When given an output data callback that expects a place to write samples in the specified
 /// sample format, return an output data callback that expects a place to write samples in the I16
 /// sample format. The `buffer_size` is in samples.
-pub(super) fn output_adapter_callback<D>(
+pub(super) fn output_adapter_callback<T, D>(
     mut original_data_callback: D,
     buffer_size: FrameCount,
-    sample_format: SampleFormat,
 ) -> Box<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>
 where
     D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    T: Sample + TypeSampleFormat + Copy + Send + Default + 'static,
 {
-    match sample_format {
-        SampleFormat::I16 => {
-            // no-op
-            return Box::new(original_data_callback);
+    let mut adapted_buf = vec![T::default(); buffer_size as usize];
+    Box::new(move |data: &mut Data, info: &OutputCallbackInfo| {
+        // Note: we construct adapted_data here instead of in the parent function because
+        // adapted_buf needs to be owned by the closure.
+        let mut adapted_data = unsafe { data_from_vec(&mut adapted_buf) };
+
+        // Populate adapted_buf / adapted_data.
+        original_data_callback(&mut adapted_data, info);
+
+        let data_slice: &mut [i16] = data.as_slice_mut().unwrap(); // unwrap OK because data is always i16
+        let adapted_slice = &adapted_buf;
+        assert_eq!(data_slice.len(), adapted_slice.len());
+        for (data_ref, adapted_element) in data_slice.iter_mut().zip(adapted_slice.iter()) {
+            *data_ref = adapted_element.to_i16();
         }
-        SampleFormat::F32 => {
-            // Make the backing buffer for the Data used in the closure.
-            let mut adapted_buf = vec![0f32].repeat(buffer_size as usize);
+    })
+}
 
-            Box::new(move |data: &mut Data, info: &OutputCallbackInfo| {
-                // Note: we construct adapted_data here instead of in the parent function because
-                // adapted_buf needs to be owned by the closure.
-                let mut adapted_data = unsafe {
-                    Data::from_parts(
-                        adapted_buf.as_mut_ptr() as *mut _,
-                        buffer_size as usize, // TODO: this is converting a FrameCount to a number of samples; invalid for stereo!
-                        sample_format,
-                    )
-                };
-
-                // Populate adapted_buf / adapted_data.
-                original_data_callback(&mut adapted_data, info);
-
-                let data_slice: &mut [i16] = data.as_slice_mut().unwrap(); // unwrap OK because data is always i16
-                let adapted_slice = &adapted_buf;
-                assert_eq!(data_slice.len(), adapted_slice.len());
-                for (i, data_ref) in data_slice.iter_mut().enumerate() {
-                    *data_ref = adapted_slice[i].to_i16();
-                }
-            })
-        }
-        SampleFormat::U16 => {
-            // Make the backing buffer for the Data used in the closure.
-            let mut adapted_buf = vec![0u16].repeat(buffer_size as usize);
-
-            Box::new(move |data: &mut Data, info: &OutputCallbackInfo| {
-                // Note: we construct adapted_data here instead of in the parent function because
-                // adapted_buf needs to be owned by the closure.
-                let mut adapted_data = unsafe {
-                    Data::from_parts(
-                        adapted_buf.as_mut_ptr() as *mut _,
-                        buffer_size as usize, // TODO: this is converting a FrameCount to a number of samples; invalid for stereo!
-                        sample_format,
-                    )
-                };
-
-                // Populate adapted_buf / adapted_data.
-                original_data_callback(&mut adapted_data, info);
-
-                let data_slice: &mut [i16] = data.as_slice_mut().unwrap(); // unwrap OK because data is always i16
-                let adapted_slice = &adapted_buf;
-                assert_eq!(data_slice.len(), adapted_slice.len());
-                for (i, data_ref) in data_slice.iter_mut().enumerate() {
-                    *data_ref = adapted_slice[i].to_i16();
-                }
-            })
-        }
-    }
+unsafe fn data_from_vec<T>(adapted_buf: &mut Vec<T>) -> Data
+where
+    T: TypeSampleFormat,
+{
+    Data::from_parts(
+        adapted_buf.as_mut_ptr() as *mut _,
+        adapted_buf.len(), // TODO: this is converting a FrameCount to a number of samples; invalid for stereo!
+        T::sample_format(),
+    )
 }

--- a/src/host/sndio/mod.rs
+++ b/src/host/sndio/mod.rs
@@ -880,10 +880,10 @@ impl DeviceTrait for Device {
             } => {
                 boxed_data_cb = match sample_format {
                     SampleFormat::F32 => {
-                        input_adapter_callback::<f32, _>(data_callback, *buffer_size, sample_format)
+                        input_adapter_callback::<f32, _>(data_callback, *buffer_size)
                     }
                     SampleFormat::U16 => {
-                        input_adapter_callback::<u16, _>(data_callback, *buffer_size, sample_format)
+                        input_adapter_callback::<u16, _>(data_callback, *buffer_size)
                     }
                     SampleFormat::I16 => Box::new(data_callback),
                 };
@@ -945,10 +945,14 @@ impl DeviceTrait for Device {
             InnerState::Running {
                 ref buffer_size, ..
             } => {
-                boxed_data_cb = if sample_format != SampleFormat::I16 {
-                    output_adapter_callback(data_callback, *buffer_size, sample_format)
-                } else {
-                    Box::new(data_callback)
+                boxed_data_cb = match sample_format {
+                    SampleFormat::F32 => {
+                        output_adapter_callback::<f32, _>(data_callback, *buffer_size)
+                    }
+                    SampleFormat::U16 => {
+                        output_adapter_callback::<u16, _>(data_callback, *buffer_size)
+                    }
+                    SampleFormat::I16 => Box::new(data_callback),
                 };
             }
         }

--- a/src/host/sndio/runner.rs
+++ b/src/host/sndio/runner.rs
@@ -261,7 +261,7 @@ pub(super) fn runner(inner_state_arc: Arc<Mutex<InnerState>>) {
                     } => {
                         if output_offset_bytes_into_buf == 0 {
                             // The whole output buffer has been written (or this is the first time). Fill it.
-                            if output_callbacks.1.len() == 0 {
+                            if output_callbacks.empty() {
                                 if clear_output_buf_needed {
                                     // There is probably nonzero data in the buffer from previous output
                                     // Streams. Zero it out.
@@ -271,7 +271,7 @@ pub(super) fn runner(inner_state_arc: Arc<Mutex<InnerState>>) {
                                     clear_output_buf_needed = false;
                                 }
                             } else {
-                                for cbs in output_callbacks.1.values_mut() {
+                                for cbs in output_callbacks.store.values_mut() {
                                     // Really we shouldn't have more than one output callback as they are
                                     // stepping on each others' data.
                                     // TODO: perhaps we should not call these callbacks while holding the lock
@@ -385,7 +385,7 @@ pub(super) fn runner(inner_state_arc: Arc<Mutex<InnerState>>) {
                             ref mut input_callbacks,
                             ..
                         } => {
-                            for cbs in input_callbacks.1.values_mut() {
+                            for cbs in input_callbacks.store.values_mut() {
                                 // TODO: perhaps we should not call these callbacks while holding the lock
                                 (cbs.data_callback)(&input_data, &input_callback_info);
                             }

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -23,6 +23,23 @@ impl SampleFormat {
     }
 }
 
+/// Returns the SampleFormat for the given standard type.
+pub trait TypeSampleFormat {
+    fn sample_format() -> SampleFormat;
+}
+
+impl TypeSampleFormat for f32 {
+    fn sample_format() -> SampleFormat { SampleFormat::F32 }
+}
+
+impl TypeSampleFormat for u16 {
+    fn sample_format() -> SampleFormat { SampleFormat::U16 }
+}
+
+impl TypeSampleFormat for i16 {
+    fn sample_format() -> SampleFormat { SampleFormat::I16 }
+}
+
 /// Trait for containers that contain PCM data.
 pub unsafe trait Sample: Copy + Clone {
     /// The `SampleFormat` corresponding to this data type.


### PR DESCRIPTION
I made some of the changes I was suggesting before as a quick exercise. I nearly forgot Rust, so it was a welcome diversion. See what you think about this stuff. If the `input_adapter_callback` change is agreeable a similar pattern can be applied to `output_adapter_callback`.

I only tested that beep example still works. Not sure if the update code even runs there.